### PR TITLE
WinGUI: fix `SignToolLocation` typos in build.xml

### DIFF
--- a/win/CS/build.xml
+++ b/win/CS/build.xml
@@ -11,7 +11,7 @@
   Example with code signing:
     msbuild build.xml /p:Platform=x64 /t:Release /p:SignThumbprint=XYZ /p:SignTimestampServer=http://time.certum.pl/
     
-  Reuqires: libhb.dll to be in the release folder.
+  Requires: libhb.dll to be in the release folder.
   
 -->
 <Project DefaultTargets="Nightly" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -49,7 +49,7 @@
 
   <!-- Code Signing Configuration -->
   <PropertyGroup Condition="'$(SignToolLocation)'==''">
-    <SighToolLocation>C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x64\SignTool.exe</SighToolLocation>
+    <SignToolLocation>C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x64\SignTool.exe</SignToolLocation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SignThumbprint)'!=''">
@@ -62,7 +62,7 @@
     <Exec Command="copy $(MSBuildProjectDirectory)\HandBrakeWPF\handbrakepineapple.ico $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release /Y" Condition="$(Platform) == 'x64'" />
     <Exec Command="xcopy $(MSBuildProjectDirectory)\doc $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release\doc /I /Y" Condition="$(Platform) == 'x64'" />
     <Exec Command="makensis $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release\MakeNightly64.nsi" Condition="$(Platform) == 'x64'" />
-    <Exec Command="&quot;$(SighToolLocation)&quot; sign /sha1 $(SignThumbprint) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\$(Platform)\Release\*Win_GUI.exe&quot;"  Condition="'$(SignThumbprint)' != ''" />
+    <Exec Command="&quot;$(SignToolLocation)&quot; sign /sha1 $(SignThumbprint) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\$(Platform)\Release\*Win_GUI.exe&quot;"  Condition="'$(SignThumbprint)' != ''" />
   </Target>
 
   <Target Name="ReleasePostBuild">
@@ -70,7 +70,7 @@
     <Exec Command="copy $(MSBuildProjectDirectory)\HandBrakeWPF\handbrakepineapple.ico $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release /Y" Condition="$(Platform) == 'x64'" />
     <Exec Command="xcopy $(MSBuildProjectDirectory)\doc $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release\doc /I /Y" Condition="$(Platform) == 'x64'" />
     <Exec Command="makensis $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release\Installer64.nsi" Condition="$(Platform) == 'x64'" />
-    <Exec Command="&quot;$(SighToolLocation)&quot; sign /sha1 $(SignThumbprint) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\$(Platform)\Release\*Win_GUI.exe&quot;"  Condition="'$(SignThumbprint)' != ''" />
+    <Exec Command="&quot;$(SignToolLocation)&quot; sign /sha1 $(SignThumbprint) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\$(Platform)\Release\*Win_GUI.exe&quot;"  Condition="'$(SignThumbprint)' != ''" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Previously, a mismatch between the condition (which checked for an empty `SignToolLocation`) and the action it took (by setting `SighToolLocation`) made it difficult to override the actual location of `SignTool.exe` using a build-time flag to `msbuild`. The bug was introduced in HandBrake/HandBrake@d375071be1158deb73ccb1d262310f15f231eca9 .

I discovered this while attempting to build my own nightlies using CI, but if the flags are used on the official project's Jenkins configuration, they might need to be rectified there too.